### PR TITLE
Adds single-direction axis

### DIFF
--- a/MinecraftJoypadSplitscreenMod/src/com/shiny/joypadmod/ControllerSettings.java
+++ b/MinecraftJoypadSplitscreenMod/src/com/shiny/joypadmod/ControllerSettings.java
@@ -62,6 +62,7 @@ public class ControllerSettings
 
 	private static Map<String, List<Integer>> validControllers;
 	private static Map<String, List<Integer>> inValidControllers;
+	private static Map<Integer, List<Integer>> singleDirectionAxis;
 	public static ControllerUtils controllerUtils;
 
 	// modDisabled will not set up the event handlers and will therefore render
@@ -90,6 +91,7 @@ public class ControllerSettings
 		controllerUtils = new ControllerUtils();
 		validControllers = new HashMap<String, List<Integer>>();
 		inValidControllers = new HashMap<String, List<Integer>>();
+		singleDirectionAxis = new HashMap<Integer, List<Integer>>();
 		joyBindingsMap = new HashMap<String, ControllerBinding>();
 		userDefinedBindings = new ArrayList<ControllerBinding>();
 		grabMouse = ControllerSettings.getGameOption("-Global-.GrabMouse").equals("true");
@@ -438,6 +440,49 @@ public class ControllerSettings
 		return validControllers.size();
 	}
 
+	/**
+	 *
+	 * @param controllerNo The index of the controller
+	 * @param axisNo The index of the axis
+	 * @return true if the axis is single-directed, and false instead
+	 */
+	public static boolean isSingleDirectionAxis(int controllerNo, int axisNo)
+	{
+		List<Integer> axis = singleDirectionAxis.getOrDefault(controllerNo, new ArrayList<Integer>());
+		return axis.contains(axisNo);
+	}
+
+	/**
+	 *
+	 * @param controllerNo The index of the controller
+	 */
+	private static void addSingleDirectionAxis(int controllerNo)
+	{
+		if (!singleDirectionAxis.containsKey(controllerNo))
+		{
+			singleDirectionAxis.put(controllerNo, new ArrayList<Integer>());
+		}
+	}
+
+	/**
+	 *
+	 * @param controllerNo The index of the controller
+	 * @param axisNo The index of the axis
+	 */
+	public static void toggleSingleDirectionAxis(int controllerNo, int axisNo)
+	{
+		addSingleDirectionAxis(controllerNo);
+		List<Integer> axis = singleDirectionAxis.get(controllerNo);
+		if (axis.contains(axisNo))
+		{
+			axis.remove(Integer.valueOf(axisNo));
+		}
+		else
+		{
+			axis.add(axisNo);
+		}
+	}
+
 	public static boolean setController(int controllerNo)
 	{
 		LogHelper.Info("Attempting to use controller " + controllerNo);
@@ -455,14 +500,17 @@ public class ControllerSettings
 				return false;
 			}
 
+			addSingleDirectionAxis(controllerNo);
+
+			Controller controller = Controllers.getController(controllerNo);
 			ControllerSettings.setDefaultJoyBindingMap(controllerNo, true);
 			joyNo = controllerNo;
-			controllerUtils.printDeadZones(Controllers.getController(controllerNo));
+			controllerUtils.printDeadZones(controller);
 			inputEnabled = true;
 
 			applySavedDeadZones(joyNo);
 
-			config.updatePreferedJoy(controllerNo, Controllers.getController(controllerNo).getName());
+			config.updatePreferedJoy(controllerNo, controller.getName());
 
 			Minecraft.getMinecraft().gameSettings.pauseOnLostFocus = false;
 			JoypadMouse.AxisReader.centerCrosshairs();

--- a/MinecraftJoypadSplitscreenMod/src/com/shiny/joypadmod/inputevent/AxisInputEvent.java
+++ b/MinecraftJoypadSplitscreenMod/src/com/shiny/joypadmod/inputevent/AxisInputEvent.java
@@ -49,12 +49,7 @@ public class AxisInputEvent extends ControllerInputEvent
 	{
 		if (!isValid())
 			return 0;
-		float rawValue = Controllers.getController(controllerNumber).getAxisValue(axisNumber);
-		if (ControllerSettings.isSingleDirectionAxis(controllerNumber, axisNumber))
-		{
-			return (rawValue + 1f) / 2f;
-		}
-		return rawValue;
+		return ControllerUtils.getAxisValue(Controllers.getController(controllerNumber), axisNumber);
 	}
 
 	@Override

--- a/MinecraftJoypadSplitscreenMod/src/com/shiny/joypadmod/inputevent/AxisInputEvent.java
+++ b/MinecraftJoypadSplitscreenMod/src/com/shiny/joypadmod/inputevent/AxisInputEvent.java
@@ -1,5 +1,6 @@
 package com.shiny.joypadmod.inputevent;
 
+import com.shiny.joypadmod.ControllerSettings;
 import org.lwjgl.input.Controllers;
 
 import com.shiny.joypadmod.helpers.LogHelper;
@@ -48,7 +49,12 @@ public class AxisInputEvent extends ControllerInputEvent
 	{
 		if (!isValid())
 			return 0;
-		return Controllers.getController(controllerNumber).getAxisValue(axisNumber);
+		float rawValue = Controllers.getController(controllerNumber).getAxisValue(axisNumber);
+		if (ControllerSettings.isSingleDirectionAxis(controllerNumber, axisNumber))
+		{
+			return (rawValue + 1f) / 2f;
+		}
+		return rawValue;
 	}
 
 	@Override

--- a/MinecraftJoypadSplitscreenMod/src/com/shiny/joypadmod/inputevent/ControllerUtils.java
+++ b/MinecraftJoypadSplitscreenMod/src/com/shiny/joypadmod/inputevent/ControllerUtils.java
@@ -3,6 +3,7 @@ package com.shiny.joypadmod.inputevent;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.shiny.joypadmod.ControllerSettings;
 import org.lwjgl.input.Controller;
 import org.lwjgl.input.Controllers;
 
@@ -112,9 +113,9 @@ public class ControllerUtils
 	{
 		if (Controllers.isEventAxis())
 		{
-			if (Math.abs(controller.getAxisValue(eventIndex)) > 0.75f)
+			if (Math.abs(ControllerUtils.getAxisValue(controller, eventIndex)) > 0.75f)
 			{
-				return new AxisInputEvent(controller.getIndex(), eventIndex, controller.getAxisValue(eventIndex),
+				return new AxisInputEvent(controller.getIndex(), eventIndex, ControllerUtils.getAxisValue(controller, eventIndex),
 						controller.getDeadZone(eventIndex));
 			}
 		}
@@ -177,7 +178,7 @@ public class ControllerUtils
 		}
 		for (int i = 0; i < controller.getAxisCount(); i++)
 		{
-			if (controller.getAxisValue(i) == -1)
+			if (ControllerUtils.getAxisValue(controller, i) == -1)
 			{
 				numberOfNegativeAxes++;
 			}
@@ -189,11 +190,21 @@ public class ControllerUtils
 	{
 		Controller controller = Controllers.getController(joyId);
 		controller.setDeadZone(axisId, 0);
-		float currentValue = Math.abs(controller.getAxisValue(axisId));
+		float currentValue = Math.abs(getAxisValue(controller, axisId));
 		LogHelper.Info("Axis: " + axisId + " currently has a value of: " + currentValue);
 		float newValue = currentValue + 0.15f;
 		controller.setDeadZone(axisId, newValue);
 		LogHelper.Info("Auto set axis " + axisId + " deadzone to " + newValue);
+	}
+
+	public static float getAxisValue(Controller controller, int axisNum)
+	{
+		float rawValue = controller.getAxisValue(axisNum);
+		if (ControllerSettings.isSingleDirectionAxis(controller.getIndex(), axisNum))
+		{
+			return (rawValue + 1f) / 2f;
+		}
+		return rawValue;
 	}
 
 	public static int findYAxisIndex(int joyId)

--- a/MinecraftJoypadSplitscreenMod/src/com/shiny/joypadmod/minecraftExtensions/JoypadCalibrationList.java
+++ b/MinecraftJoypadSplitscreenMod/src/com/shiny/joypadmod/minecraftExtensions/JoypadCalibrationList.java
@@ -131,7 +131,7 @@ public class JoypadCalibrationList extends GuiScrollingList
 			int totalWidth = parent.axisBoxWidth;
 			drawAxis(var1, this.width / 2 - totalWidth / 2, var3 + 2, 21, k, i1, totalWidth);
 
-			for (int i = 5 * var1; i < 5 * var1 + 4; i++)
+			for (int i = 5 * var1; i < 5 * var1 + 5; i++)
 			{
 				if (buttonList.size() > i)
 				{
@@ -158,7 +158,7 @@ public class JoypadCalibrationList extends GuiScrollingList
 		yPos += 10;
 		int xPos = xStart + 5;
 
-		String output = title + ": " + df.format(controller.getAxisValue(axisNum));
+		String output = title + ": " + df.format(ControllerUtils.getAxisValue(controller, axisNum));
 		parent.write(xPos, yPos, output);
 		xPos += maxSize + parent.fr.getStringWidth(" -1.00") + 4;
 		output = McObfuscationHelper.lookupString("calibrationMenu.deadzone") + ": "

--- a/MinecraftJoypadSplitscreenMod/src/com/shiny/joypadmod/minecraftExtensions/JoypadCalibrationList.java
+++ b/MinecraftJoypadSplitscreenMod/src/com/shiny/joypadmod/minecraftExtensions/JoypadCalibrationList.java
@@ -4,6 +4,7 @@ import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.shiny.joypadmod.ControllerSettings;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.ScaledResolution;
@@ -99,6 +100,18 @@ public class JoypadCalibrationList extends GuiScrollingList
 			axisId -= 300;
 			controller.setDeadZone(axisId, controller.getDeadZone(axisId) + 0.01f);
 		}
+		else if (guiButton.id >= 400 && guiButton.id < 500)
+		{
+			// toggle the single direction property of the axis
+			axisId -= 400;
+			ControllerSettings.toggleSingleDirectionAxis(joypadIndex, axisId);
+			char toggleSign = McObfuscationHelper.symGet(McObfuscationHelper.JSyms.eCircle);
+			if (ControllerSettings.isSingleDirectionAxis(joypadIndex, axisId))
+			{
+				toggleSign = McObfuscationHelper.symGet(McObfuscationHelper.JSyms.fCircle);
+			}
+			guiButton.displayString = "" + toggleSign;
+		}
 	}
 
 	public List<GuiButton> buttonList = new ArrayList<GuiButton>();
@@ -118,7 +131,7 @@ public class JoypadCalibrationList extends GuiScrollingList
 			int totalWidth = parent.axisBoxWidth;
 			drawAxis(var1, this.width / 2 - totalWidth / 2, var3 + 2, 21, k, i1, totalWidth);
 
-			for (int i = 4 * var1; i < 4 * var1 + 4; i++)
+			for (int i = 5 * var1; i < 5 * var1 + 4; i++)
 			{
 				if (buttonList.size() > i)
 				{
@@ -157,8 +170,17 @@ public class JoypadCalibrationList extends GuiScrollingList
 
 		int yOffset = -7;
 		int xOffset = 2;
-		if (this.buttonList.size() <= 4 * axisNum)
+		if (this.buttonList.size() <= 5 * axisNum)
 		{
+			// Single direction axis toggle button
+			char toggleSign = McObfuscationHelper.symGet(McObfuscationHelper.JSyms.eCircle);
+			if (ControllerSettings.isSingleDirectionAxis(joypadIndex, axisNum))
+			{
+				toggleSign = McObfuscationHelper.symGet(McObfuscationHelper.JSyms.fCircle);
+			}
+			buttonList.add(new GuiButton(axisNum + 400, xPos2, yPos + yOffset, directionButWidth, 20, "" + toggleSign));
+			xPos2 -= directionButWidth - xOffset;
+
 			buttonList.add(new GuiButton(axisNum + 300, xPos2, yPos + yOffset, directionButWidth, 20, ">"));
 			xPos2 -= resetButtonWidth - xOffset;
 			buttonList.add(new GuiButton(axisNum + 200, xPos2, yPos + yOffset, resetButtonWidth, 20,

--- a/MinecraftJoypadSplitscreenMod/src/com/shiny/joypadmod/minecraftExtensions/JoypadCalibrationMenu.java
+++ b/MinecraftJoypadSplitscreenMod/src/com/shiny/joypadmod/minecraftExtensions/JoypadCalibrationMenu.java
@@ -23,7 +23,7 @@ public class JoypadCalibrationMenu extends GuiScreen
 	private int joypadIndex;
 	private int yStart = 5;
 	private int buttonBoxWidth = 132;
-	public int axisBoxWidth = 275;
+	public int axisBoxWidth = 300;
 	private int povBoxWidth;
 	private int instructionBoxWidth;
 


### PR DESCRIPTION
As we discussed in #3, controller drivers does not have exactly the same behaviour in Windows and Linux, especially for the xbox 360 cotroller. For now, Minecraft uses LWJGL 1.9.1 which is based on DirectInput (on Windows) for the joypads. With DirectInput, the triggers of the 360 controller are put on the same axis (Z). In Linux, at least with all currently known drivers, the two triggers are put on separated axis, with values in the range [-1,1].
Windows users don't have any problems with it because Z is a double-directions axis and they can bind the triggers as Z+ and Z-.
Linux drivers recognize the triggers as two different axis (lets say Z1 and Z2), but LWJGL interprets them as two-directions axis like Z on Windows. The result is that on Linux, the rest value of Z1 and Z2 is -1, and LWJGL interprets it as an input (Z1- or Z2-).

These changes provide a GUI element (a button), to let the user tell if an axis must be interpreted as a single-direction axis, like the triggers on Linux. When we read the value of the axis from LWJGL, and if the axis is a single-direction axis, then we modify the value to put it in the range [0,1], instead of [-1,1].

The commit d32ed96 is meant to centralize all the calls to LWJGL for getting the axis value in one method in ControllerUtils, and then do the check described before in this method.