### PR TITLE
adds persistence for single-direction axis settings

### DIFF
--- a/MinecraftJoypadSplitscreenMod/build.gradle
+++ b/MinecraftJoypadSplitscreenMod/build.gradle
@@ -60,7 +60,7 @@ version = "1.8-0.15"
 
 minecraft {
     version = "1.8-11.14.3.1518"
-    
+    runDir = "run"
     // the mappings can be changed at any time, and must be in the following format.
     // snapshot_YYYYMMDD   snapshot are built nightly.
     // stable_#            stables are built at the discretion of the MCP team.

--- a/MinecraftJoypadSplitscreenMod/src/com/shiny/joypadmod/ControllerSettings.java
+++ b/MinecraftJoypadSplitscreenMod/src/com/shiny/joypadmod/ControllerSettings.java
@@ -442,6 +442,12 @@ public class ControllerSettings
 						LogHelper.Info("Controller #" + joyIndex + " ( " + thisController.getName()
 								+ ") meets the input requirements");
 						addControllerToList(validControllers, thisController.getName(), joyIndex);
+						String axisStr = config.getConfigFileSetting("-SingleDirectionAxis-."+thisController.getName());
+						if (axisStr != null && !axisStr.equals("") && !axisStr.equals("false"))
+						{
+							setSingleDirectionAxis(joyIndex, stringToAxisList(axisStr));
+							LogHelper.Info("Retrieved informations about single-direction axis");
+						}
 					}
 					else
 					{
@@ -459,6 +465,34 @@ public class ControllerSettings
 
 		LogHelper.Info("Found " + validControllers.size() + " valid controllers!");
 		return validControllers.size();
+	}
+
+	private static String axisListToString(List<Integer> axisList)
+	{
+		StringBuilder sb = new StringBuilder();
+		for(Integer axis: axisList)
+		{
+			sb.append(axis);
+			sb.append(',');
+		}
+		sb.deleteCharAt(sb.length() - 1);
+		return sb.toString();
+	}
+
+	private static List<Integer> stringToAxisList(String axisStr)
+	{
+		List<Integer> ret = new ArrayList<Integer>();
+		for (String axis : axisStr.split(","))
+		{
+			try
+			{
+				ret.add(Integer.parseInt(axis));
+			}
+			catch (NumberFormatException e)
+			{
+			}
+		}
+		return ret;
 	}
 
 	/**
@@ -487,6 +521,11 @@ public class ControllerSettings
 		}
 	}
 
+	private static void setSingleDirectionAxis(int controllerNo, List<Integer> axisList)
+	{
+		singleDirectionAxis.put(controllerNo, axisList);
+	}
+
 	/**
 	 *
 	 * @param controllerNo The index of the controller
@@ -505,7 +544,7 @@ public class ControllerSettings
 			axis.add(axisNo);
 		}
 	}
-	
+
 	/**
 	 *
 	 * @param controllerNo The index of the controller
@@ -820,9 +859,8 @@ public class ControllerSettings
 				+ ControllerSettings.inMenuSensitivity);
 	}
 
-	public static void saveDeadZones(int joyId)
+	public static void saveDeadZones(Controller controller)
 	{
-		Controller controller = Controllers.getController(joyId);
 		DecimalFormat df = new DecimalFormat("#0.00");
 
 		for (int i = 0; i < controller.getAxisCount(); i++)
@@ -832,6 +870,14 @@ public class ControllerSettings
 		}
 		config.addComment("-Deadzones-", "Deadzone values here will override values in individual bindings");
 		LogHelper.Info("Saved deadzones for " + controller.getName());
+	}
+
+	public static void saveSingleDirectionAxis(Controller controller)
+	{
+		List<Integer> axis = getSingleDirectionAxis(controller.getIndex());
+		config.setConfigFileSetting("-SingleDirectionAxis-", controller.getName(), axisListToString(axis));
+		config.addComment("-SingleDirectionAxis-", "Set single-direction axis for this controller");
+		LogHelper.Info("Saved single-direction axis for " + controller.getName());
 	}
 
 	private static void saveCurrentJoyBindings()

--- a/MinecraftJoypadSplitscreenMod/src/com/shiny/joypadmod/helpers/ConfigFile.java
+++ b/MinecraftJoypadSplitscreenMod/src/com/shiny/joypadmod/helpers/ConfigFile.java
@@ -152,7 +152,7 @@ public class ConfigFile
 		int lastIndex = categoryKey.lastIndexOf('.');
 		String category = categoryKey.substring(0, lastIndex);
 		String key = categoryKey.substring(lastIndex + 1);
-		return config.get(category, key, false).getString();
+		return config.get(category, key, "false").getString();
 	}
 
 	public void setConfigFileSetting(String categoryKey, String value)

--- a/MinecraftJoypadSplitscreenMod/src/com/shiny/joypadmod/minecraftExtensions/JoypadCalibrationMenu.java
+++ b/MinecraftJoypadSplitscreenMod/src/com/shiny/joypadmod/minecraftExtensions/JoypadCalibrationMenu.java
@@ -130,7 +130,9 @@ public class JoypadCalibrationMenu extends GuiScreen
 		{
 		case 400: // Save
 			singleDirectionAxisSaved = new ArrayList<Integer>(ControllerSettings.getSingleDirectionAxis(joypadIndex));
-			ControllerSettings.saveDeadZones(joypadIndex);
+			Controller controller = Controllers.getController(joypadIndex);
+			ControllerSettings.saveDeadZones(controller);
+			ControllerSettings.saveSingleDirectionAxis(controller);
 			((GuiButton) buttonList.get(1)).displayString = McObfuscationHelper.lookupString("gui.done");
 			break;
 		case 500: // Done


### PR DESCRIPTION
I added the persistence by using general config file settings. I created a new category "-SingleDirectionAxis-" and each controller is a key-value pair with the controller name as key and a list of single-direction axis as value.