### PR TITLE
Updated for 1.11.2 for forge-1.11.2-13.20.0.2228

### DIFF
--- a/MinecraftJoypadSplitscreenMod/build.gradle
+++ b/MinecraftJoypadSplitscreenMod/build.gradle
@@ -20,7 +20,7 @@ allprojects {
 
 
    
-version = "1.11-13.19.1.2195"
+version = "1.11.2-13.20.0.2228"
 group = "com.shiny.joypadmod"
 archivesBaseName = "JoypadMod"
 
@@ -31,7 +31,7 @@ compileJava {
 
 
 minecraft {
-    version = "1.11-13.19.1.2195"
+    version = "1.11.2-13.20.0.2228"
     runDir = "run"
     // the mappings can be changed at any time, and must be in the following format.
     // snapshot_YYYYMMDD   snapshot are built nightly.

--- a/MinecraftJoypadSplitscreenMod/src/main/java/com/shiny/joypadmod/JoypadMod.java
+++ b/MinecraftJoypadSplitscreenMod/src/main/java/com/shiny/joypadmod/JoypadMod.java
@@ -20,7 +20,7 @@ import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 
 
 @Mod(modid = JoypadMod.MODID, name = JoypadMod.NAME, version = ModVersionHelper.VERSION + "-" + JoypadMod.MINVERSION
-		+ JoypadMod.REVISION, clientSideOnly = true, acceptedMinecraftVersions = "[1.11.0,)")
+		+ JoypadMod.REVISION, clientSideOnly = true, acceptedMinecraftVersions = "[1.11.2,)")
 // 1.6.4
 // @NetworkMod(serverSideRequired = false)
 public class JoypadMod

--- a/MinecraftJoypadSplitscreenMod/src/main/java/com/shiny/joypadmod/helpers/ModVersionHelper.java
+++ b/MinecraftJoypadSplitscreenMod/src/main/java/com/shiny/joypadmod/helpers/ModVersionHelper.java
@@ -20,7 +20,7 @@ import net.minecraft.client.gui.ScaledResolution;
 
 public class ModVersionHelper
 {
-	public static final String VERSION = "1.11.0";
+	public static final String VERSION = "1.11.2";
 	
 	public static final int MC_VERSION = 1110;
 

--- a/MinecraftJoypadSplitscreenMod/src/main/resources/mcmod.info
+++ b/MinecraftJoypadSplitscreenMod/src/main/resources/mcmod.info
@@ -2,7 +2,7 @@
 {
   "modid": "joypadsplitscreenmod",
   "name": "Joypad / SplitScreen Mod",
-  "version": "1.11-13.19.0.2165",
+  "version": "1.11.2-13.20.0.2228",
   "description": "Play Minecraft splitscreen using gamepad controllers!!",
   "url": "http://retro-hack.blogspot.com/p/minecraft-joypad-mod.html",
   "updateUrl": "github.com/ljsimin/MinecraftJoypadSplitscreenMod",  


### PR DESCRIPTION
Updated for 1.11.2 for forge-1.11.2-13.20.0.2228.

I had to use the snapshot 20161111 as later versions caused compilation errors.

Tested and it works (1.11.2 allows  now disconnect and reconnect without restarting)